### PR TITLE
add eviction, annotation term

### DIFF
--- a/trans-glossary.md
+++ b/trans-glossary.md
@@ -19,6 +19,8 @@ sorted alphabetically
 - control plane, 控制平面
 - credential, 登录凭据, [根据上下文] 凭据
 - drain, 耗尽资源
+- evict, 驱逐
+- eviction, 驱逐回收
 - flags, 命令行参数, [根据上下文] 参数
 - healthcheck, 健康检查
 - key, 密钥

--- a/trans-glossary.md
+++ b/trans-glossary.md
@@ -8,6 +8,7 @@ sorted alphabetically
 
 >译前术语参考
 
+- annotation, 注解
 - API Server, API 服务器
 - Bearer Token, 持有者令牌
 - certificate, 证书


### PR DESCRIPTION

eviction 有驱逐的意味，而且出现在 GC 上下文环境，所以译为 ”驱逐回收”

原文：

`MaxPerPodContainer` would be adjusted in this situation: A worst case scenario would be to downgrade `MaxPerPodContainer` to 1 and **evict** the oldest containers.

Some kubelet Garbage Collection features in this doc will be replaced by kubelet **eviction** in the future.